### PR TITLE
chore: add info field in products and templat fielde in categories

### DIFF
--- a/src/collections/Categories.ts
+++ b/src/collections/Categories.ts
@@ -14,6 +14,10 @@ const Categories: CollectionConfig = {
       type: 'text',
       required: true,
     },
+    {
+      name: 'template',
+      type: 'richText',
+    },
   ],
 }
 

--- a/src/collections/Products/hooks/infoAfterChange.ts
+++ b/src/collections/Products/hooks/infoAfterChange.ts
@@ -1,0 +1,23 @@
+import type { FieldHook } from 'payload/types'
+import payload from 'payload'
+
+export const getCategoriesTemplate = async (categoryId: string) => {
+  try {
+    const category = await payload.findByID({
+      collection: 'categories',
+      id: categoryId,
+    });
+
+    return category.template;
+  } catch (error) {
+    throw error;
+  }
+};
+
+export const infoAfterChange: FieldHook = async ({ data, operation }) => {
+  if (data && (operation === 'create' || operation === 'update')) {
+    data.info = await getCategoriesTemplate(data.categories);
+  }
+
+  return data;
+};

--- a/src/collections/Products/index.ts
+++ b/src/collections/Products/index.ts
@@ -11,6 +11,7 @@ import { populateArchiveBlock } from '../../hooks/populateArchiveBlock'
 import { deleteProductFromCarts } from './hooks/deleteProductFromCarts'
 import { revalidateProduct } from './hooks/revalidateProduct'
 import { checkRole } from '../Users/checkRole'
+import { infoAfterChange } from './hooks/infoAfterChange'
 
 const Products: CollectionConfig = {
   slug: 'products',
@@ -78,10 +79,14 @@ const Products: CollectionConfig = {
           label: 'Content',
           fields: [
             {
-              name: 'layout',
-              type: 'blocks',
-              required: true,
-              blocks: [CallToAction, Content, MediaBlock, Archive],
+              name: 'info',
+              type: 'richText',
+              admin: {
+                condition: (data) => !!data.category,
+              },
+              hooks: {
+                afterChange: [infoAfterChange],
+              },
             },
           ],
         },

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -41,6 +41,9 @@ export interface Config {
 export interface Category {
   id: string;
   title: string;
+  template: {
+    [k: string]: unknown
+  }[];
   updatedAt: string;
   createdAt: string;
 }


### PR DESCRIPTION
implement remove field “layout” in product and add field “info”, whose type is text editor, then add field “template” in category, whose type is richtext.
Field “info” should show after selecting category and when initializing info field by replicating the template field in category 